### PR TITLE
Skip matplotlib dependency on RPM releases

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -107,7 +107,10 @@ tracks:
     - git-bloom-generate -y rosdebian --prefix release/:{ros_distro} :{ros_distro}
       -i :{release_inc} --os-name debian --os-not-required
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
-      :{release_inc}
+      :{release_inc} --os-name fedora
+    - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
+      :{release_inc} --os-name rhel
+      --skip-keys python3-matplotlib
     devel_branch: crystal-devel
     last_version: 1.0.8
     name: upstream


### PR DESCRIPTION
This package is not currently available for the only RPM distribution we're targeting in Eloquent, CentOS 7. One of the plot providers (such as this one) will need to be installed manually via pip. There aren't any downstream consumers of this package, so the absence of this dependency shouldn't block any other packages from building.

This PR should be held until ros-infrastructure/bloom#604 is merged, since the action list will be changed at that time.